### PR TITLE
feat: cardano-wallet 2026.5.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3 AS cardano-wallet-build
+FROM ghcr.io/blinklabs-io/haskell:9.12.3-3.14.2.0-1 AS cardano-wallet-build
 # Install cardano-wallet
-ARG WALLET_VERSION=2025.3.31
+ARG WALLET_VERSION=2026.5.11
 ENV WALLET_VERSION=${WALLET_VERSION}
-ARG WALLET_REF=tags/v2025-03-31
+ARG WALLET_REF=tags/v2026-05-11
 ENV WALLET_REF=${WALLET_REF}
 RUN echo "Building ${WALLET_REF}..." \
     && echo ${WALLET_REF} > /CARDANO_BRANCH \
@@ -13,9 +13,9 @@ RUN echo "Building ${WALLET_REF}..." \
     && git checkout ${WALLET_REF} \
     && cabal configure --with-compiler=ghc-${GHC_VERSION} --disable-tests --disable-benchmarks \
     && cabal update \
-    && cabal build all -frelease \
+    && cabal build exe:cardano-wallet -frelease \
     && mkdir -p /root/.local/bin/ \
-    && cp -a dist-newstyle/build/$(uname -m)-linux/ghc-${GHC_VERSION}/cardano-wallet-application-${WALLET_VERSION}/x/cardano-wallet/build/cardano-wallet/cardano-wallet /root/.local/bin/ \
+    && cp -a "$(cabal list-bin exe:cardano-wallet)" /root/.local/bin/ \
     && rm -rf /root/.cabal/packages \
     && rm -rf /usr/local/lib/ghc-${GHC_VERSION}/ /usr/local/share/doc/ghc-${GHC_VERSION}/ \
     && rm -rf /code/cardano-wallet/dist-newstyle/ \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `cardano-wallet` to 2026.5.11 and switch to `ghcr.io/blinklabs-io/haskell:9.12.3-3.14.2.0-1` for compatibility. Build only the `cardano-wallet` executable and copy it via `cabal list-bin` to simplify and speed up the Docker build.

- **Dependencies**
  - `WALLET_VERSION`: 2025.3.31 → 2026.5.11 (`WALLET_REF` tags/v2026-05-11)
  - Base image: `ghcr.io/blinklabs-io/haskell:9.6.7-3.12.1.0-3` → `ghcr.io/blinklabs-io/haskell:9.12.3-3.14.2.0-1`

<sup>Written for commit c97e9e94d136e7577a45a97c926ba108f554ba92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-cardano-wallet/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment to a newer base image.
  * Advanced the default wallet version to a more recent release, so builds now use the latest supported source by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->